### PR TITLE
feat: Get detailed info from albums

### DIFF
--- a/app/src/main/java/com/example/vynilsapp/network/NetworkServiceAdapter.kt
+++ b/app/src/main/java/com/example/vynilsapp/network/NetworkServiceAdapter.kt
@@ -34,7 +34,20 @@ class NetworkServiceAdapter constructor(context: Context) {
 
     private val gson = Gson()
 
-    fun getAlbums(onComplete: (resp: List<Album>) -> Unit, onError: (error: VolleyError) -> Unit) {
+    fun getAlbum(id: String, onComplete: (Album) -> Unit, onError: (VolleyError) -> Unit) {
+        requestQueue.add(getRequest("albums/$id",
+            { response ->
+                try {
+                    val album = gson.fromJson(response, Album::class.java)
+                    onComplete(album)
+                } catch (e: Exception) {
+                    onError(VolleyError(e.message))
+                }
+            },
+            { onError(it) }))
+    }
+
+    fun getAlbums(onComplete: (List<Album>) -> Unit, onError: (VolleyError) -> Unit) {
         requestQueue.add(getRequest("albums",
             { response ->
                 try {

--- a/app/src/main/java/com/example/vynilsapp/repositories/AlbumRepository.kt
+++ b/app/src/main/java/com/example/vynilsapp/repositories/AlbumRepository.kt
@@ -16,7 +16,16 @@ class AlbumRepository(val application: Application) {
         )
     }
 
-    fun createAlbum(albumRequest: CreateAlbumRequest, onComplete: (Album) -> Unit, onError: (VolleyError) -> Unit) {
-        NetworkServiceAdapter.getInstance(application).createAlbum(albumRequest, onComplete, onError)
+    fun getAlbum(id: String, onComplete: (Album) -> Unit, onError: (VolleyError) -> Unit) {
+        NetworkServiceAdapter.getInstance(application).getAlbum(id, onComplete, onError)
+    }
+
+    fun createAlbum(
+        albumRequest: CreateAlbumRequest,
+        onComplete: (Album) -> Unit,
+        onError: (VolleyError) -> Unit
+    ) {
+        NetworkServiceAdapter.getInstance(application)
+            .createAlbum(albumRequest, onComplete, onError)
     }
 }

--- a/app/src/main/java/com/example/vynilsapp/ui/AlbumDetailFragment.kt
+++ b/app/src/main/java/com/example/vynilsapp/ui/AlbumDetailFragment.kt
@@ -1,0 +1,80 @@
+package com.example.vynilsapp.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import com.example.vynilsapp.databinding.FragmentAlbumDetailBinding
+import com.example.vynilsapp.viewmodels.AlbumDetailViewModel
+import com.squareup.picasso.Picasso
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class AlbumDetailFragment : Fragment() {
+
+    private var _binding: FragmentAlbumDetailBinding? = null
+    private val binding get() = _binding!!
+    private lateinit var viewModel: AlbumDetailViewModel
+    private var shouldRefreshData = true
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentAlbumDetailBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val activity = requireActivity()
+        viewModel = ViewModelProvider(this, AlbumDetailViewModel.Factory(activity.application))
+            .get(AlbumDetailViewModel::class.java)
+
+        viewModel.albumDetail.observe(viewLifecycleOwner) { albumDetail ->
+            albumDetail?.let {
+                binding.progressCircular.visibility = View.GONE
+                binding.lanzamientoAlbumDetail.text = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault()).parse(it.releaseDate)!!)
+                binding.descripcionAlbumDetail.text = it.description
+                binding.selloAlbumDetail.text = it.recordLabel
+                binding.generoAlbumDetail.text = it.genre
+                binding.albumDetailName.text = it.name
+                if (it.cover.isNotEmpty()) {
+                    Picasso.get().load(it.cover).into(binding.albumDetailCover)
+                }
+            }
+        }
+
+        viewModel.eventNetworkError.observe(viewLifecycleOwner) { isNetworkError ->
+            if (isNetworkError) onNetworkError()
+        }
+
+        val albumId = arguments?.get("albumId")?.toString() ?: return
+        viewModel.getAlbumDetail(albumId)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (shouldRefreshData) {
+            binding.progressCircular.visibility = View.VISIBLE
+            viewModel.refreshDataFromNetwork()
+            shouldRefreshData = false
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun onNetworkError() {
+        if (!viewModel.isNetworkErrorShown.value!!) {
+            Toast.makeText(activity, "Error de red", Toast.LENGTH_LONG).show()
+            viewModel.onNetworkErrorShown()
+        }
+    }
+}

--- a/app/src/main/java/com/example/vynilsapp/ui/AlbumFragment.kt
+++ b/app/src/main/java/com/example/vynilsapp/ui/AlbumFragment.kt
@@ -1,6 +1,7 @@
 package com.example.vynilsapp.ui
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -60,6 +61,12 @@ class AlbumFragment : Fragment() {
             }
         }
 
+        // Click on cover and navigate to detail
+        viewModelAdapter!!.onClick = { album ->
+            Log.i("AlbumFragment", "Album clicked: ${album.name}")
+           val action = AlbumFragmentDirections.actionAlbumFragmentToAlbumDetailFragment(album.albumId)
+           findNavController().navigate(action)
+        }
         
         // Inicializar ViewModel
         val activity = requireActivity()

--- a/app/src/main/java/com/example/vynilsapp/ui/adapters/AlbumsAdapter.kt
+++ b/app/src/main/java/com/example/vynilsapp/ui/adapters/AlbumsAdapter.kt
@@ -18,6 +18,8 @@ class AlbumsAdapter : RecyclerView.Adapter<AlbumsAdapter.AlbumViewHolder>(){
             notifyDataSetChanged()
         }
 
+    var onClick: ((Album) -> Unit)? = null
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AlbumViewHolder {
         val withDataBinding: AlbumItemBinding = DataBindingUtil.inflate(
             LayoutInflater.from(parent.context),
@@ -36,11 +38,12 @@ class AlbumsAdapter : RecyclerView.Adapter<AlbumsAdapter.AlbumViewHolder>(){
         if (album.cover.isNotEmpty()) {
             Picasso.get().load(album.cover).into(holder.viewDataBinding.albumCover)
         }
+        holder.itemView.setOnClickListener {
+            onClick?.invoke(album)
+        }
     }
 
-    override fun getItemCount(): Int {
-        return albums.size
-    }
+    override fun getItemCount(): Int = albums.size
 
     class AlbumViewHolder(val viewDataBinding: AlbumItemBinding) :
         RecyclerView.ViewHolder(viewDataBinding.root) {

--- a/app/src/main/java/com/example/vynilsapp/viewmodels/AlbumDetailViewModel.kt
+++ b/app/src/main/java/com/example/vynilsapp/viewmodels/AlbumDetailViewModel.kt
@@ -1,0 +1,57 @@
+package com.example.vynilsapp.viewmodels
+
+import android.app.Application
+import androidx.lifecycle.*
+import com.example.vynilsapp.models.Album
+import com.example.vynilsapp.repositories.AlbumRepository
+
+class AlbumDetailViewModel(application: Application) : AndroidViewModel(application) {
+    private val albumsRepository = AlbumRepository(application)
+    private val _albums = MutableLiveData<List<Album>>()
+    val albums: LiveData<List<Album>> get() = _albums
+
+    private val _albumDetail = MutableLiveData<Album>()
+    val albumDetail: LiveData<Album> get() = _albumDetail
+
+    private val _eventNetworkError = MutableLiveData<Boolean>(false)
+    val eventNetworkError: LiveData<Boolean> get() = _eventNetworkError
+
+    private val _isNetworkErrorShown = MutableLiveData<Boolean>(false)
+    val isNetworkErrorShown: LiveData<Boolean> get() = _isNetworkErrorShown
+
+    init {
+        refreshDataFromNetwork()
+    }
+
+    fun refreshDataFromNetwork() {
+        albumsRepository.refreshData({
+            _albums.postValue(it)
+            _eventNetworkError.value = false
+            _isNetworkErrorShown.value = false
+        }, {
+            _eventNetworkError.value = true
+        })
+    }
+
+    fun getAlbumDetail(albumId: String) {
+        albumsRepository.getAlbum(albumId, { album ->
+            _albumDetail.postValue(album)
+        }, {
+            _eventNetworkError.value = true
+        })
+    }
+
+    fun onNetworkErrorShown() {
+        _isNetworkErrorShown.value = true
+    }
+
+    class Factory(val app: Application) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(AlbumDetailViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return AlbumDetailViewModel(app) as T
+            }
+            throw IllegalArgumentException("Unable to construct viewmodel")
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_album_detail.xml
+++ b/app/src/main/res/layout/fragment_album_detail.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="albumDetail"
+            type="com.example.vynilsapp.models.Album" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="16dp">
+
+
+        <!-- Foto del album -->
+        <ImageView
+            android:id="@+id/albumDetailCover"
+            android:layout_width="0dp"
+            android:layout_height="200dp"
+            android:scaleType="fitXY"
+            android:background="@android:color/darker_gray"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <TextView
+            android:id="@+id/albumDetailName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:textAlignment="center"
+            app:layout_constraintTop_toBottomOf="@id/albumDetailCover"
+            />
+
+        <!-- LANZAMIENTO -->
+        <TextView
+            android:id="@+id/lanzamientoAlbumDetailLabel"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:text="@string/album_release"
+            app:layout_constraintTop_toBottomOf="@id/albumDetailName"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginTop="16dp" />
+
+        <TextView
+            android:id="@+id/lanzamientoAlbumDetail"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/lanzamientoAlbumDetailLabel"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <!-- GÉNERO -->
+        <TextView
+            android:id="@+id/generoAlbumDetailLabel"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/album_genre"
+            android:textStyle="bold"
+            android:layout_marginTop="12dp"
+            app:layout_constraintTop_toBottomOf="@id/lanzamientoAlbumDetail"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <TextView
+            android:id="@+id/generoAlbumDetail"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/generoAlbumDetailLabel"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <!-- SELLO -->
+        <TextView
+            android:id="@+id/selloAlbumDetailLabel"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/album_record_label"
+            android:textStyle="bold"
+            android:layout_marginTop="12dp"
+            app:layout_constraintTop_toBottomOf="@id/generoAlbumDetail"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <TextView
+            android:id="@+id/selloAlbumDetail"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/selloAlbumDetailLabel"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <!-- DESCRIPCIÓN -->
+        <TextView
+            android:id="@+id/descripcionAlbumDetailLabel"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/album_description"
+            android:textStyle="bold"
+            android:layout_marginTop="12dp"
+            app:layout_constraintTop_toBottomOf="@id/selloAlbumDetail"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <TextView
+            android:id="@+id/descripcionAlbumDetail"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/descripcionAlbumDetailLabel"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <!-- Botón volver -->
+<!--        <Button-->
+<!--            android:id="@+id/btnBack"-->
+<!--            android:layout_width="0dp"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:text="@string/back_button"-->
+<!--            android:layout_marginTop="24dp"-->
+<!--            app:layout_constraintTop_toBottomOf="@id/descripcionAlbumDetail"-->
+<!--            app:layout_constraintBottom_toBottomOf="parent"-->
+<!--            app:layout_constraintStart_toStartOf="parent"-->
+<!--            app:layout_constraintEnd_toEndOf="parent" />-->
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/progressCircular"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="visible"
+            android:contentDescription="@string/loading"
+            android:indeterminate="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -42,6 +42,18 @@
         <action
             android:id="@+id/action_albumFragment_to_createAlbumFragment"
             app:destination="@id/createAlbumFragment" />
+        <action
+            android:id="@+id/action_albumFragment_to_albumDetailFragment"
+            app:destination="@id/albumDetailFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/albumDetailFragment"
+        android:name="com.example.vynilsapp.ui.AlbumDetailFragment"
+        tools:layout="@layout/fragment_album_detail">
+        <argument
+            android:name="albumId"
+            app:argType="integer" />
     </fragment>
 
     <fragment

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,9 @@
     <string name="todos_los_performers">Todos los artistas</string>
     <string name="performer_catalog_list">Todos los artistas</string>
 
+    <!-- Strings del detalle del album -->
+    <string name="album_release">Lanzamiento</string>
+    <string name="back_button">Volver</string>
 
 
 


### PR DESCRIPTION
This pull request introduces functionality to display detailed information about an album, including navigation from the album list to a new album detail screen. It involves changes across the network layer, repository, UI components, and navigation graph. The most significant updates include the addition of a new `AlbumDetailFragment`, integration of a click listener for album selection, and support for fetching album details from the backend.

### New Album Detail Feature:

* **`AlbumDetailFragment` Implementation**: Added a new fragment (`AlbumDetailFragment`) to display album details, including its layout (`fragment_album_detail.xml`) and associated ViewModel (`AlbumDetailViewModel`). The fragment observes album details and network error states, fetching data via the repository. [[1]](diffhunk://#diff-359e55ade6e5fc218b401c1052e27afec7e8c85ec1aaf378f5a8de6bd6611d9eR1-R80) [[2]](diffhunk://#diff-3fd237ddd74b56f92be870d530d1174456be00616c7230ab522dec8fb55c7a17R1-R57) [[3]](diffhunk://#diff-e6fb62b99c1ad0bf1fbd2c580dd152fb2534ba8c458a94fe32b40dd4264371deR1-R142)
* **Navigation to Album Detail**: Updated the navigation graph (`nav_graph.xml`) to include a new action and fragment for album details. Clicking on an album in the list triggers navigation to this fragment. [[1]](diffhunk://#diff-df40eb110ac93ade5b364a6b9980556ce3b2c7208ce2814bcb34abd484e7b4acR45-R56) [[2]](diffhunk://#diff-eab705ef5954d579f0f9b3dfc7d6938731b568253bbcfea9857e60ac0cd833a2R64-R69)

### Network and Repository Enhancements:

* **Fetch Single Album**: Added a `getAlbum` method in `NetworkServiceAdapter` and `AlbumRepository` to retrieve details of a specific album by its ID. [[1]](diffhunk://#diff-05f5993158d45058dfaad376cd6ee184d245886c77d8983f768838c51694b365L37-R50) [[2]](diffhunk://#diff-2868dc73ebc2bc072ac7a5254ef2ac852f26c2004e98b363dac858bc11689b15L19-R29)

### UI Updates:

* **Click Listener in Album List**: Introduced a click listener in `AlbumsAdapter` to handle album selection and trigger navigation to the detail screen. [[1]](diffhunk://#diff-b4b5d927768a115efd24f3b4775f889b0952ae21e6b61ab5b86c5ff1d10ad6fbR21-R22) [[2]](diffhunk://#diff-b4b5d927768a115efd24f3b4775f889b0952ae21e6b61ab5b86c5ff1d10ad6fbR41-R47)

### Miscellaneous:

* **String Resources**: Added new string resources for album detail labels (e.g., release date, genre, description).
* **Debug Logging**: Added a debug log to track album clicks in `AlbumFragment`.